### PR TITLE
Ability to set arbitrary tags for the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Add ECR settings to your `build.sbt`. The following snippet assumes a Docker ima
     // Authenticate and publish a local Docker image before pushing to ECR
     push in ecr <<= (push in ecr) dependsOn (publishLocal in Docker, login in ecr)
 
+It is possible to provide arbitrary additional tags for an image pushed to amazon ECR, for example to set "latest" tag to the image
+    
+    additionalTags   in ecr := Seq("latest")
+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Add ECR settings to your `build.sbt`. The following snippet assumes a Docker ima
     region           in ecr := Region.getRegion(Regions.US_EAST_1)
     repositoryName   in ecr := (packageName in Docker).value
     localDockerImage in ecr := (packageName in Docker).value + ":" + (version in Docker).value
-    version          in ecr := (version in Docker).value
 
     // Create the repository before authentication takes place (optional)
     login in ecr <<= (login in ecr) dependsOn (createRepository in ecr)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,14 @@ Add ECR settings to your `build.sbt`. The following snippet assumes a Docker ima
     // Authenticate and publish a local Docker image before pushing to ECR
     push in ecr <<= (push in ecr) dependsOn (publishLocal in Docker, login in ecr)
 
-It is possible to provide arbitrary additional tags for an image pushed to amazon ECR, for example to set "latest" tag to the image
+## Tagging
+
+By default, the produced image will be tagged as "latest". It is possible to provide arbitrary additional tags,
+ for example to add the version tag to the image:
     
-    additionalTags   in ecr := Seq("latest")
+    repositoryTags in ecr ++= Seq(version.value)
+    
+If you don't want latest tag on your image you could override the ```repositoryTags``` value completely:
+ 
+    repositoryTags in ecr := Seq(version.value)
 

--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -2,7 +2,6 @@ package sbtecr
 
 import com.amazonaws.regions.Region
 import sbt.Keys._
-import sbt.Keys.version
 import sbt._
 
 import scala.language.postfixOps


### PR DESCRIPTION
With the release of 0.5.0 the image marked as "latest" only when the version is not provided in ecr.
Here is the PR that allows putting arbitrary tags to the image, i.e. "latest"