### PR TITLE
Support sbt-1.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ hs_err_pid*
 ### Intellij ###
 .idea_modules/
 .idea/
+
+### Temporary files ###
+tmp/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An [SBT](http://www.scala-sbt.org/) plugin for managing [Docker](http://docker.i
 
 Add the following to your `project/plugins.sbt` file:
 
-    addSbtPlugin("com.mintbeans" % "sbt-ecr" % "0.7.1")
+    addSbtPlugin("com.mintbeans" % "sbt-ecr" % "0.8.0")
 
 Add ECR settings to your `build.sbt`. The following snippet assumes a Docker image build using [sbt-native-packager](https://github.com/sbt/sbt-native-packager):
 

--- a/README.md
+++ b/README.md
@@ -22,24 +22,24 @@ Add ECR settings to your `build.sbt`. The following snippet assumes a Docker ima
     
     enablePlugins(EcrPlugin)
 
-    region           in ecr := Region.getRegion(Regions.US_EAST_1)
-    repositoryName   in ecr := (packageName in Docker).value
-    localDockerImage in ecr := (packageName in Docker).value + ":" + (version in Docker).value
+    region           in Ecr := Region.getRegion(Regions.US_EAST_1)
+    repositoryName   in Ecr := (packageName in Docker).value
+    localDockerImage in Ecr := (packageName in Docker).value + ":" + (version in Docker).value
 
     // Create the repository before authentication takes place (optional)
-    login in ecr <<= (login in ecr) dependsOn (createRepository in ecr)
+    login in Ecr := ((login in Ecr) dependsOn (createRepository in Ecr)).value
 
     // Authenticate and publish a local Docker image before pushing to ECR
-    push in ecr <<= (push in ecr) dependsOn (publishLocal in Docker, login in ecr)
+    push in Ecr := ((push in Ecr) dependsOn (publishLocal in Docker, login in Ecr)).value
 
 ## Tagging
 
 By default, the produced image will be tagged as "latest". It is possible to provide arbitrary additional tags,
  for example to add the version tag to the image:
     
-    repositoryTags in ecr ++= Seq(version.value)
+    repositoryTags in Ecr ++= Seq(version.value)
     
 If you don't want latest tag on your image you could override the ```repositoryTags``` value completely:
  
-    repositoryTags in ecr := Seq(version.value)
+    repositoryTags in Ecr := Seq(version.value)
 

--- a/bintray.sbt
+++ b/bintray.sbt
@@ -5,4 +5,4 @@ bintrayVcsUrl        := Some("git@github.com:sbilinski/sbt-ecr.git")
 publishMavenStyle       := false
 publishArtifact in Test := false
 
-publish <<= publish dependsOn (test in Test)
+publish := (publish dependsOn (test in Test)).value

--- a/bintray.sbt
+++ b/bintray.sbt
@@ -5,4 +5,18 @@ bintrayVcsUrl        := Some("git@github.com:sbilinski/sbt-ecr.git")
 publishMavenStyle       := false
 publishArtifact in Test := false
 
-publish := (publish dependsOn (test in Test)).value
+// Release
+import ReleaseTransformations._
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  releaseStepCommandAndRemaining("^ test"),
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  releaseStepCommandAndRemaining("^ publish"),
+  setNextVersion,
+  commitNextVersion
+)

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,16 @@ description   := "sbt plugin for managing Amazon ECR repositories"
 startYear     := Some(2016)
 version       := "0.8.0-SNAPSHOT"
 licenses      += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-scalaVersion  := "2.10.6"
-scalacOptions := Seq("-unchecked", "-feature", "-deprecation", "-encoding", "utf8")
+
+sbtVersion in Global := "1.0.3"
+crossSbtVersions     := List("0.13.16", "1.0.3")
+scalaVersion         := "2.12.4"
+scalacOptions        := Seq("-unchecked", "-feature", "-deprecation", "-encoding", "utf8")
+
+scalaCompilerBridgeSource := {
+  val sv = appConfiguration.value.provider.id.version
+  ("org.scala-sbt" % "compiler-interface" % sv % "component").sources
+}
 
 libraryDependencies ++= {
   val amazonSdkV = "1.11.33"

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ name          := "sbt-ecr"
 organization  := "com.mintbeans"
 description   := "sbt plugin for managing Amazon ECR repositories"
 startYear     := Some(2016)
-version       := "0.8.0-SNAPSHOT"
 licenses      += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 
 sbtVersion in Global := "1.0.3"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.12
+sbt.version = 0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 logLevel := Level.Warn
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")

--- a/src/main/scala-2.10/sbtecr/Commands.scala
+++ b/src/main/scala-2.10/sbtecr/Commands.scala
@@ -1,0 +1,14 @@
+package sbtecr
+
+import sbt._
+
+import scala.language.postfixOps
+
+private[sbtecr] object Commands {
+
+  def exec(cmd: String)(implicit logger: Logger): Int = {
+    logger.debug(s"Executing (2.10): ${cmd}")
+    Process(cmd) !
+  }
+
+}

--- a/src/main/scala-2.12/sbtecr/Commands.scala
+++ b/src/main/scala-2.12/sbtecr/Commands.scala
@@ -1,0 +1,15 @@
+package sbtecr
+
+import sbt.Logger
+
+import scala.language.postfixOps
+import scala.sys.process._
+
+private[sbtecr] object Commands {
+
+  def exec(cmd: String)(implicit logger: Logger): Int = {
+    logger.debug(s"Executing (2.12): ${cmd}")
+    cmd!
+  }
+
+}

--- a/src/main/scala/sbtecr/AwsEcr.scala
+++ b/src/main/scala/sbtecr/AwsEcr.scala
@@ -9,7 +9,7 @@ import sbt.Logger
 
 import scala.collection.JavaConverters._
 
-private[sbtecr] object Ecr extends Aws {
+private[sbtecr] object AwsEcr extends Aws {
 
   def domain(region: Region, accountId: String) = s"${accountId}.dkr.ecr.${region}.${region.getDomain}"
 

--- a/src/main/scala/sbtecr/AwsSts.scala
+++ b/src/main/scala/sbtecr/AwsSts.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
 import sbt.Logger
 
-private[sbtecr] object Sts extends Aws {
+private[sbtecr] object AwsSts extends Aws {
 
   def accountId(region: Region)(implicit logger: Logger): String = {
     val request = new GetCallerIdentityRequest()

--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -3,18 +3,19 @@ package sbtecr
 import com.amazonaws.regions.Region
 import sbt.Keys._
 import sbt._
+import sbtecr.Commands._
 
 import scala.language.postfixOps
 
 object EcrPlugin extends AutoPlugin {
 
   object autoImport {
-      lazy val ecr = config("ecr")
+      lazy val Ecr = config("ecr")
 
       lazy val region           = settingKey[Region]("Amazon EC2 region.")
       lazy val repositoryName   = settingKey[String]("Amazon ECR repository name.")
       lazy val localDockerImage = settingKey[String]("Local Docker image.")
-      lazy val repositoryTags   = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository")
+      lazy val repositoryTags   = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository.")
 
       lazy val createRepository = taskKey[Unit]("Create a repository in Amazon ECR.")
       lazy val login            = taskKey[Unit]("Login to Amazon ECR.")
@@ -22,7 +23,7 @@ object EcrPlugin extends AutoPlugin {
   }
 
   import autoImport._
-  override lazy val projectSettings = inConfig(ecr)(defaultSettings ++ tasks)
+  override lazy val projectSettings = inConfig(Ecr)(defaultSettings ++ tasks)
 
   lazy val defaultSettings: Seq[Def.Setting[_]] = Seq(
     repositoryTags := List("latest"),
@@ -32,14 +33,14 @@ object EcrPlugin extends AutoPlugin {
   lazy val tasks: Seq[Def.Setting[_]] = Seq(
     createRepository := {
       implicit val logger = streams.value.log
-      Ecr.createRepository(region.value, repositoryName.value)
+      AwsEcr.createRepository(region.value, repositoryName.value)
     },
     login := {
       implicit val logger = streams.value.log
-      val accountId = Sts.accountId(region.value)
-      val (user, pass) = Ecr.dockerCredentials(region.value)
-      val cmd = List("docker", "login", "-u", user, "-p", pass, s"https://${Ecr.domain(region.value, accountId)}")
-      Process(cmd)! match {
+      val accountId = AwsSts.accountId(region.value)
+      val (user, pass) = AwsEcr.dockerCredentials(region.value)
+      val cmd = s"docker login -u ${user} -p ${pass} https://${AwsEcr.domain(region.value, accountId)}"
+      exec(cmd) match {
         case 0 =>
         case _ =>
           sys.error(s"Login failed. Command: ${cmd.mkString(" ")}")
@@ -48,24 +49,22 @@ object EcrPlugin extends AutoPlugin {
     push := {
       implicit val logger = streams.value.log
 
-      val accountId = Sts.accountId(region.value)
+      val accountId = AwsSts.accountId(region.value)
 
       val src = localDockerImage.value
-      def destination(tag: String) = s"${Ecr.domain(region.value, accountId)}/${repositoryName.value}:$tag"
+      def destination(tag: String) = s"${AwsEcr.domain(region.value, accountId)}/${repositoryName.value}:$tag"
 
       repositoryTags.value.foreach { tag =>
         val dst = destination(tag)
-        val command = List("docker", "tag", src, dst)
-        Process(command) ! match {
+        exec(s"docker tag ${src} ${dst}") match {
           case 0 =>
-            val push = List("docker", "push", dst)
-            Process(push) ! match {
+            exec(s"docker push ${dst}") match {
               case 0 =>
               case _ =>
-                sys.error(s"Pushing failed. Command: ${push.mkString(" ")}")
+                sys.error(s"Pushing failed. Target image: ${dst}")
             }
           case _ =>
-            sys.error(s"Tagging failed. Command: ${command.mkString(" ")}")
+            sys.error(s"Tagging failed. Source image: ${src} Target image: ${dst}")
         }
       }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.0-SNAPSHOT"
+version in ThisBuild := "0.8.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.0"
+version in ThisBuild := "0.9.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.8.0-SNAPSHOT"


### PR DESCRIPTION
Enable cross-building for sbt `0.13.x` and `1.0.x`:

* Upgrade `sbt` version for the project to `0.13.16` (sbt-cross-building support).
* Rename config namespace from `ecr` to `Ecr` (a capitalized id is strictly required by `1.x.x`)
* Adjust internal class names for clarity and to avoid conflicts with the new namespace id.
* Adjust setup instructions.
* Use [sbt-release](https://github.com/sbt/sbt-release) plugin for simpler publishing process.