### PR TITLE
Fix login error message formatting

### DIFF
--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -43,7 +43,7 @@ object EcrPlugin extends AutoPlugin {
       exec(cmd) match {
         case 0 =>
         case _ =>
-          sys.error(s"Login failed. Command: ${cmd.mkString(" ")}")
+          sys.error(s"Login failed. Command: $cmd")
       }
     },
     push := {


### PR DESCRIPTION
`cmd` here is a string so `cmd.mkString(" ")` would take string and treat it like a `List[Char]` and insert spaces between each one. So `hello world` becomes `h e l l o  w o r l d`. 

Instead we can just grab the string and insert it into the error message.