### PR TITLE
Support EC2 container instance in provider chain

### DIFF
--- a/src/main/scala/sbtecr/Aws.scala
+++ b/src/main/scala/sbtecr/Aws.scala
@@ -10,6 +10,6 @@ private[sbtecr] trait Aws {
       new EnvironmentVariableCredentialsProvider(),
       new SystemPropertiesCredentialsProvider(),
       new ProfileCredentialsProvider(sys.env.getOrElse("AWS_DEFAULT_PROFILE", "default")),
-      InstanceProfileCredentialsProvider.getInstance()
+      new EC2ContainerCredentialsProviderWrapper()
     )
 }


### PR DESCRIPTION
Connects to #22.
Implements option 2 by using `EC2ContainerCredentialsProviderWrapper` which wraps the current `InstanceProfileCredentialsProvider` and allows for credentials provided by ECS and code build.