### PR TITLE
Add ECR Repository policy option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,37 @@ And trigger the process using:
 
     VERSION_TAG=myfeature sbt ecr:push
 
+## Repository policy configuration
+
+By default, when the `createRepository` task is executed, the new repository does not have a policy
+attached. 
+
+When you set `repositoryPolicyText` in your `build.sbt` file, and the `createRepository` is called, the created
+repository will have the configured policy. 
+
+Example usage:
+    
+    repositoryPolicyText in Ecr := Some(IO.read(file("project") / "ecrpolicy.json")) 
+    
+Then in the `project/ecrpolicy.json` you can set your policy text. For example:
+    
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "BuildServerAccess",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::YOUR_ACCOUNT_ID_HERE:role/YOUR_IAM_ROLE_NAME_HERE"
+            ]
+          },
+          "Action": [
+            "ecr:*"
+          ]
+        }
+      ]
+    }
+ 
+Configuring `repositoryPolicyText` will not affect existing repositories.
+

--- a/src/main/scala/sbtecr/AwsEcr.scala
+++ b/src/main/scala/sbtecr/AwsEcr.scala
@@ -3,7 +3,7 @@ package sbtecr
 import java.util.Base64
 
 import com.amazonaws.regions.Region
-import com.amazonaws.services.ecr.AmazonECRClientBuilder
+import com.amazonaws.services.ecr.{AmazonECR, AmazonECRClientBuilder}
 import com.amazonaws.services.ecr.model._
 import sbt.Logger
 
@@ -13,17 +13,27 @@ private[sbtecr] object AwsEcr extends Aws {
 
   def domain(region: Region, accountId: String) = s"${accountId}.dkr.ecr.${region}.${region.getDomain}"
 
-  def createRepository(region: Region, repositoryName: String)(implicit logger: Logger): Unit = {
+  def createRepository(region: Region, repositoryName: String, repositoryPolicyTextOption : Option[String])(implicit logger: Logger): Unit = {
+    val client = ecr(region)
     val request = new CreateRepositoryRequest()
     request.setRepositoryName(repositoryName)
 
     try {
-      val result = ecr(region).createRepository(request)
+      val result = client.createRepository(request)
       logger.info(s"Repository created in ${region}: arn=${result.getRepository.getRepositoryArn}")
+      repositoryPolicyTextOption.foreach(setPolicy(client, repositoryName, _))
     } catch {
       case e: RepositoryAlreadyExistsException =>
         logger.info(s"Repository exists: ${region}/${repositoryName}")
     }
+  }
+
+  def setPolicy(ecr : AmazonECR, repositoryName : String, repositoryPolicyText : String)(implicit logger: Logger) : Unit = {
+    val request = new SetRepositoryPolicyRequest()
+        .withRepositoryName(repositoryName)
+        .withPolicyText(repositoryPolicyText)
+    ecr.setRepositoryPolicy(request)
+    logger.info("Configured policy for ECR repository.")
   }
 
   def dockerCredentials(region: Region)(implicit logger: Logger): (String, String) = {

--- a/src/main/scala/sbtecr/AwsEcr.scala
+++ b/src/main/scala/sbtecr/AwsEcr.scala
@@ -13,7 +13,7 @@ private[sbtecr] object AwsEcr extends Aws {
 
   def domain(region: Region, accountId: String) = s"${accountId}.dkr.ecr.${region}.${region.getDomain}"
 
-  def createRepository(region: Region, repositoryName: String, repositoryPolicyTextOption : Option[String])(implicit logger: Logger): Unit = {
+  def createRepository(region: Region, repositoryName: String, repositoryPolicyText: Option[String])(implicit logger: Logger): Unit = {
     val client = ecr(region)
     val request = new CreateRepositoryRequest()
     request.setRepositoryName(repositoryName)
@@ -21,14 +21,14 @@ private[sbtecr] object AwsEcr extends Aws {
     try {
       val result = client.createRepository(request)
       logger.info(s"Repository created in ${region}: arn=${result.getRepository.getRepositoryArn}")
-      repositoryPolicyTextOption.foreach(setPolicy(client, repositoryName, _))
+      repositoryPolicyText.foreach(setPolicy(client, repositoryName, _))
     } catch {
       case e: RepositoryAlreadyExistsException =>
         logger.info(s"Repository exists: ${region}/${repositoryName}")
     }
   }
 
-  def setPolicy(ecr : AmazonECR, repositoryName : String, repositoryPolicyText : String)(implicit logger: Logger) : Unit = {
+  private def setPolicy(ecr : AmazonECR, repositoryName : String, repositoryPolicyText : String)(implicit logger: Logger): Unit = {
     val request = new SetRepositoryPolicyRequest()
         .withRepositoryName(repositoryName)
         .withPolicyText(repositoryPolicyText)

--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -12,14 +12,15 @@ object EcrPlugin extends AutoPlugin {
   object autoImport {
       lazy val Ecr = config("ecr")
 
-      lazy val region           = settingKey[Region]("Amazon EC2 region.")
-      lazy val repositoryName   = settingKey[String]("Amazon ECR repository name.")
-      lazy val localDockerImage = settingKey[String]("Local Docker image.")
-      lazy val repositoryTags   = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository.")
+      lazy val region               = settingKey[Region]("Amazon EC2 region.")
+      lazy val repositoryName       = settingKey[String]("Amazon ECR repository name.")
+      lazy val repositoryPolicyText = settingKey[Option[String]]("Amazon ECR policy.")
+      lazy val localDockerImage     = settingKey[String]("Local Docker image.")
+      lazy val repositoryTags       = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository.")
 
-      lazy val createRepository = taskKey[Unit]("Create a repository in Amazon ECR.")
-      lazy val login            = taskKey[Unit]("Login to Amazon ECR.")
-      lazy val push             = taskKey[Unit]("Push a Docker image to Amazon ECR.")
+      lazy val createRepository     = taskKey[Unit]("Create a repository in Amazon ECR.")
+      lazy val login                = taskKey[Unit]("Login to Amazon ECR.")
+      lazy val push                 = taskKey[Unit]("Push a Docker image to Amazon ECR.")
   }
 
   import autoImport._
@@ -27,13 +28,14 @@ object EcrPlugin extends AutoPlugin {
 
   lazy val defaultSettings: Seq[Def.Setting[_]] = Seq(
     repositoryTags := List("latest"),
+    repositoryPolicyText := None,
     localDockerImage := s"${repositoryName.value}:${version.value}"
   )
 
   lazy val tasks: Seq[Def.Setting[_]] = Seq(
     createRepository := {
       implicit val logger = streams.value.log
-      AwsEcr.createRepository(region.value, repositoryName.value)
+      AwsEcr.createRepository(region.value, repositoryName.value, repositoryPolicyText.value)
     },
     login := {
       implicit val logger = streams.value.log


### PR DESCRIPTION
- Add optional property 'repositoryPolicyText'. When specified, will set the repository policy when creating a new ECR repository.
- Tested