### PR TITLE
Add lifecycle policy support for the createRepository task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An [SBT](http://www.scala-sbt.org/) plugin for managing [Docker](http://docker.i
 
 Add the following to your `project/plugins.sbt` file:
 
-    addSbtPlugin("com.mintbeans" % "sbt-ecr" % "0.13.0")
+    addSbtPlugin("com.mintbeans" % "sbt-ecr" % "0.14.0")
 
 Add ECR settings to your `build.sbt`. The following snippet assumes a Docker image build using [sbt-native-packager](https://github.com/sbt/sbt-native-packager):
 
@@ -84,4 +84,42 @@ Then in the `project/ecrpolicy.json` you can set your policy text. For example:
     }
  
 Configuring `repositoryPolicyText` will not affect existing repositories.
+
+## Repository lifecycle policy configuration
+Configuring the repository lifecycle policy works the same as configuring the policy in the previous chapter.
+
+By default, when the `createRepository` task is executed, the new repository does not have a lifecycle 
+policy attached. 
+
+When you set `repositoryLifecyclePolicyText` in your `build.sbt` file, and the `createRepository` is called, the created
+repository will have the configured lifecycle policy. 
+
+Example usage:
+    
+    repositoryLifecyclePolicyText in Ecr := Some(IO.read(file("project") / "ecrlifecyclepolicy.json")) 
+    
+Then in the `project/ecrlifecyclepolicy.json` you can set your policy text. For example:
+    
+    {
+      "rules": [
+        {
+          "rulePriority": 10,
+          "description": "Lifecycle of release branch images",
+          "selection": {
+            "tagStatus": "tagged",
+            "tagPrefixList": [
+              "release"
+            ],
+            "countType": "imageCountMoreThan",
+            "countNumber": 20
+          },
+          "action": {
+            "type": "expire"
+          }
+        }
+      ]
+    }
+ 
+Configuring `repositoryLifecyclePolicyText` will not affect existing repositories.
+
 

--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -12,16 +12,17 @@ object EcrPlugin extends AutoPlugin {
   object autoImport {
       lazy val Ecr = config("ecr")
 
-      lazy val region               = settingKey[Region]("Amazon EC2 region.")
-      lazy val repositoryName       = settingKey[String]("Amazon ECR repository name.")
-      lazy val repositoryPolicyText = settingKey[Option[String]]("Amazon ECR policy.")
-      lazy val localDockerImage     = settingKey[String]("Local Docker image.")
-      lazy val repositoryTags       = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository.")
+      lazy val region                         = settingKey[Region]("Amazon EC2 region.")
+      lazy val repositoryName                 = settingKey[String]("Amazon ECR repository name.")
+      lazy val repositoryPolicyText           = settingKey[Option[String]]("Amazon ECR access policy.")
+      lazy val repositoryLifecyclePolicyText  = settingKey[Option[String]]("Amazon ECR lifecycle policy.")
+      lazy val localDockerImage               = settingKey[String]("Local Docker image.")
+      lazy val repositoryTags                 = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository.")
 
-      lazy val repositoryDomain     = taskKey[String]("Domain of the Amazon ECR repository.")
-      lazy val createRepository     = taskKey[Unit]("Create a repository in Amazon ECR.")
-      lazy val login                = taskKey[Unit]("Login to Amazon ECR.")
-      lazy val push                 = taskKey[Unit]("Push a Docker image to Amazon ECR.")
+      lazy val repositoryDomain               = taskKey[String]("Domain of the Amazon ECR repository.")
+      lazy val createRepository               = taskKey[Unit]("Create a repository in Amazon ECR.")
+      lazy val login                          = taskKey[Unit]("Login to Amazon ECR.")
+      lazy val push                           = taskKey[Unit]("Push a Docker image to Amazon ECR.")
   }
 
   import autoImport._
@@ -41,7 +42,7 @@ object EcrPlugin extends AutoPlugin {
     },
     createRepository := {
       implicit val logger = streams.value.log
-      AwsEcr.createRepository(region.value, repositoryName.value, repositoryPolicyText.value)
+      AwsEcr.createRepository(region.value, repositoryName.value, repositoryPolicyText.value, repositoryLifecyclePolicyText.value)
     },
     login := {
       implicit val logger = streams.value.log


### PR DESCRIPTION
Repositories can have a lifecycle policy to automatically clean old images from the ECR repository.
This feature allows you to set the lifecycle policy in the same way you could add the ECR access policy.

I tested it and the lifecycle policy is correctly added to AWS, when using the steps in the readme.