### PR TITLE
Use the default contructr for ProfileCredentialsProvider

### DIFF
--- a/src/main/scala/sbtecr/Aws.scala
+++ b/src/main/scala/sbtecr/Aws.scala
@@ -9,7 +9,7 @@ private[sbtecr] trait Aws {
     new AWSCredentialsProviderChain(
       new EnvironmentVariableCredentialsProvider(),
       new SystemPropertiesCredentialsProvider(),
-      new ProfileCredentialsProvider(sys.env.getOrElse("AWS_DEFAULT_PROFILE", "default")),
+      new ProfileCredentialsProvider(),
       new EC2ContainerCredentialsProviderWrapper()
     )
 }


### PR DESCRIPTION
This PR uses the default constructor for `ProfileCredentialsProvider`. This aligns the plugin with all the others AWS code that uses the `AWS_PROFILE` environment variable to load the profile, rather than the deprecated `AWS_DEFAULT_PROFILE`.

Fixes #47 