### PR TITLE
Add Vulnerabilities Scan Capability on ECR Repository Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ By default, when the `createRepository` task is executed, the new repository wil
 disabled. You can control this behavior using the following setting:
 
     imageTagsMutable in Ecr := false
+
+## Image Scanning
+By default, when the `createRepository` task is executed, the new repository will have **Image Scanning**
+enabled. You can control this behavior using the following setting:
+
+    scanOnPush in Ecr := false
  
 ## Cross account publishing
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ sbtVersion in pluginCrossBuild := {
 scalacOptions := Seq("-unchecked", "-feature", "-deprecation", "-encoding", "utf8")
 
 libraryDependencies ++= {
-  val amazonSdkV = "1.11.672"
-  val scalaTestV = "3.0.8"
+  val amazonSdkV = "1.12.186"
+  val scalaTestV = "3.2.11"
   Seq(
     "com.amazonaws"  %  "aws-java-sdk-sts"   % amazonSdkV,
     "com.amazonaws"  %  "aws-java-sdk-ecr"   % amazonSdkV,

--- a/src/main/scala/sbtecr/AwsEcr.scala
+++ b/src/main/scala/sbtecr/AwsEcr.scala
@@ -16,12 +16,19 @@ private[sbtecr] object AwsEcr extends Aws {
   def createRepository(region: Region,
                        repositoryName: String,
                        imageTagsMutable: Boolean,
+                       scanOnPush: Boolean,
                        repositoryPolicyText: Option[String],
                        repositoryLifecyclePolicyText: Option[String])(implicit logger: Logger): Unit = {
+
     val client = ecr(region)
 
     try {
-      val result = client.createRepository(new CreateRepositoryRequest().withRepositoryName(repositoryName).withImageTagMutability(if (imageTagsMutable) ImageTagMutability.MUTABLE else ImageTagMutability.IMMUTABLE))
+      val result = client.createRepository(
+        new CreateRepositoryRequest()
+          .withRepositoryName(repositoryName)
+          .withImageTagMutability(if (imageTagsMutable) ImageTagMutability.MUTABLE else ImageTagMutability.IMMUTABLE)
+          .withImageScanningConfiguration(new ImageScanningConfiguration().withScanOnPush(scanOnPush))
+      )
       logger.info(s"Repository created in ${region}: arn=${result.getRepository.getRepositoryArn}")
       repositoryPolicyText.foreach(setPolicy(client, repositoryName, _))
       repositoryLifecyclePolicyText.foreach(putLifecyclePolicy(client, repositoryName, _))

--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -21,7 +21,7 @@ object EcrPlugin extends AutoPlugin {
       lazy val localDockerImage               = settingKey[String]("Local Docker image.")
       lazy val repositoryTags                 = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository.")
       lazy val imageTagsMutable               = settingKey[Boolean]("Boolean as to whether to make image tags mutable or not")
-      lazy val scanOnPush                     = settingKey[Boolean]("Enable vunerabilities scan on image push")
+      lazy val scanOnPush                     = settingKey[Boolean]("Enable vulnerabilities scan on image push")
 
       lazy val fetchDomain                    = taskKey[String]("Fetch active domain for Amazon ECR access.")
       lazy val createRepository               = taskKey[Unit]("Create a repository in Amazon ECR.")

--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -21,6 +21,7 @@ object EcrPlugin extends AutoPlugin {
       lazy val localDockerImage               = settingKey[String]("Local Docker image.")
       lazy val repositoryTags                 = settingKey[Seq[String]]("Tags managed in the Amazon ECR repository.")
       lazy val imageTagsMutable               = settingKey[Boolean]("Boolean as to whether to make image tags mutable or not")
+      lazy val scanOnPush                     = settingKey[Boolean]("Enable vunerabilities scan on image push")
 
       lazy val fetchDomain                    = taskKey[String]("Fetch active domain for Amazon ECR access.")
       lazy val createRepository               = taskKey[Unit]("Create a repository in Amazon ECR.")
@@ -38,7 +39,8 @@ object EcrPlugin extends AutoPlugin {
     repositoryLifecyclePolicyText := None,
     localDockerImage := s"${repositoryName.value}:${version.value}",
     repositoryDomain := None,
-    imageTagsMutable := true
+    imageTagsMutable := true,
+    scanOnPush       :=true,
   )
 
   lazy val tasks: Seq[Def.Setting[_]] = Seq(
@@ -55,7 +57,13 @@ object EcrPlugin extends AutoPlugin {
     },
     createRepository := {
       implicit val logger = streams.value.log
-      AwsEcr.createRepository(region.value, repositoryName.value, imageTagsMutable.value, repositoryPolicyText.value, repositoryLifecyclePolicyText.value)
+      AwsEcr.createRepository(
+        region.value, repositoryName.value,
+        imageTagsMutable.value,
+        scanOnPush.value,
+        repositoryPolicyText.value,
+        repositoryLifecyclePolicyText.value
+      )
     },
     login := {
       implicit val logger = streams.value.log

--- a/src/main/scala/sbtecr/EcrPlugin.scala
+++ b/src/main/scala/sbtecr/EcrPlugin.scala
@@ -40,7 +40,7 @@ object EcrPlugin extends AutoPlugin {
     localDockerImage := s"${repositoryName.value}:${version.value}",
     repositoryDomain := None,
     imageTagsMutable := true,
-    scanOnPush       :=true,
+    scanOnPush       := true,
   )
 
   lazy val tasks: Seq[Def.Setting[_]] = Seq(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.17.0-SNAPSHOT"
+version in ThisBuild := "0.18.0-SNAPSHOT"


### PR DESCRIPTION
This PR adds an option called scanOnPush. That will enable the scanOnPush for ImageScanningConfiguration. README Updated as well.